### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The buttons have the same ring effect on click. The buttons are more customizabl
 
 <p align="center"><img title="Button click animation" src="https://raw.githubusercontent.com/edekhayser/FrostedSidebar/master/callouts.gif"/></p>
 
-##Usage##
+## Usage ##
 
 In the example project, the sidebar is added quite easily.
 
@@ -76,7 +76,7 @@ import FrostedSidebar
 1. Download and drop ```FrostedSidebar.swift``` in your project.  
 2. Congratulations!  
 
-##Conclusion##
+## Conclusion ##
 
 This would not be possible without the impressive work by Ryan Nystrom, and the great design by [Jakub Antalík on Dribbble](https://dribbble.com/shots/1194205-Sidebar-calendar-animation). 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
